### PR TITLE
Do not try PyPI upload on schedule

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,13 @@ jobs:
   ##    a regular commit/push.
   ##
   UploadPyPI:
-    if: success() && github.actor == 'btschwertfeger' && github.ref == 'refs/heads/master'
+    if: |
+      success()
+      && github.actor == 'btschwertfeger'
+      && (
+        (github.event_name == 'push' && github.ref == 'refs/heads/master')
+        || github.event_name == 'release'
+      )
     needs: [Build, Pre-Commit, CodeQL]
     name: Upload current development version to Test PyPI
     uses: ./.github/workflows/_pypi_publish.yaml


### PR DESCRIPTION
Lets not upload to PyPI in scheduled pipelines as a version can't get uploaded twice.